### PR TITLE
Propagate login error messages to the UI

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -40,11 +40,18 @@ export function LoginForm() {
       const result = await dispatch(loginUser(data));
       if (loginUser.fulfilled.match(result)) {
         router.push("/principal");
-      } else {
-        setError("root", { message: "Credenciales inválidas" });
+      } else if (loginUser.rejected.match(result)) {
+        const message =
+          (result.payload as string) ||
+          result.error.message ||
+          "Credenciales inválidas";
+        setError("root", { message });
+        console.error("Error de login:", message);
       }
-    } catch (error) {
-      setError("root", { message: "Error de conexión" });
+    } catch (error: any) {
+      const message = error?.message || "Error de conexión";
+      setError("root", { message });
+      console.error("Error de login:", message);
     }
   };
 

--- a/src/lib/store/authSlice.ts
+++ b/src/lib/store/authSlice.ts
@@ -110,6 +110,7 @@ export const loginUser = createAsyncThunk<
     persistSession(user, "cookie-session");
     return { user, token: "cookie-session" };
   } catch (onlineErr: any) {
+    const errorMessage = onlineErr?.message || "No se pudo iniciar sesión";
     // Fallback OFFLINE (sin red o sin cookie pero con usuario local)
     const offline = await authenticateUser(email, password);
     if (offline) {
@@ -117,7 +118,7 @@ export const loginUser = createAsyncThunk<
       persistSession(user, "offline");
       return { user, token: "offline" };
     }
-    return rejectWithValue(onlineErr?.message || "No se pudo iniciar sesión");
+    return rejectWithValue(errorMessage);
   }
 });
 


### PR DESCRIPTION
## Summary
- Preserve online login error message and propagate via rejectWithValue
- Display backend error message in login form and log it for debugging

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*
- `npm run lint` *(fails: Next.js ESLint plugin setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cf4cb1dc83208d0d99eabee5226d