### PR TITLE
Relax CouchDB login password validation

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -17,8 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { loginUser } from "@/lib/store/authSlice";
-import { loginSchema } from "@/lib/validations";
-import type { LoginCredentials } from "@/lib/types";
+import { loginSchema, type LoginSchema } from "@/lib/validations";
 
 export function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
@@ -31,11 +30,11 @@ export function LoginForm() {
     handleSubmit,
     formState: { errors },
     setError,
-  } = useForm<LoginCredentials>({
+  } = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),
   });
 
-  const onSubmit = async (data: LoginCredentials) => {
+  const onSubmit = async (data: LoginSchema) => {
     try {
       const result = await dispatch(loginUser(data));
       if (loginUser.fulfilled.match(result)) {

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -7,12 +7,11 @@ export const loginSchema = z.object({
     .email("Formato de correo inválido"),
   password: z
     .string()
-    .min(8, "La contraseña debe tener al menos 8 caracteres")
-    .regex(
-      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/,
-      "La contraseña debe contener al menos: 1 mayúscula, 1 minúscula, 1 número y 1 carácter especial",
-    ),
+    // CouchDB no impone restricciones de complejidad, solo requiere un valor
+    .min(1, "La contraseña es requerida"),
 });
+
+export type LoginSchema = z.infer<typeof loginSchema>;
 
 // --- Permisos y roles ---
 const availablePermissions = [


### PR DESCRIPTION
## Summary
- Allow any non-empty password in `loginSchema` and export its type
- Validate login form with the updated `LoginSchema`

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_68a8cf4c54608320b4ba27b31bfa8e5e