### PR TITLE
Seed Maria Acosta default user

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -218,18 +218,31 @@ export async function initializeDefaultUsers() {
   await openDatabases();
   if (!localDB) return;
   const now = new Date().toISOString();
-  const def = buildUserDocFromData({
-    name: "Mario Acosta",
-    email: "mario_acosta@purp.com.mx",
-    password: "Purp_*2023@",
-    role: "manager",
-    permissions: ["read", "write", "delete", "manage_users"],
-    createdAt: now,
-  });
-  try {
-    await localDB.get(def._id);
-  } catch (e: any) {
-    if (e?.status === 404) await localDB.put(def);
+  const seeds = [
+    {
+      name: "Mario Acosta",
+      email: "mario_acosta@purp.com.mx",
+      password: "Purp_*2023@",
+      role: "manager",
+      permissions: ["read", "write", "delete", "manage_users"],
+      createdAt: now,
+    },
+    {
+      name: "Maria Acosta",
+      email: "maria_acosta@purp.com.mx",
+      password: "Purp_*2023@",
+      role: "manager",
+      permissions: ["read", "write", "delete", "manage_users"],
+      createdAt: now,
+    },
+  ];
+  for (const data of seeds) {
+    const def = buildUserDocFromData(data);
+    try {
+      await localDB.get(def._id);
+    } catch (e: any) {
+      if (e?.status === 404) await localDB.put(def);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- seed default users for both Mario and Maria Acosta
- ensure seeding covers new maria_acosta@purp.com.mx account

## Testing
- `npx tsx -e "process.env.NEXT_PUBLIC_COUCHDB_URL='http://localhost:5984/gestion_pwa'; (global as any).window = { fetch: fetch }; (async () => { const db = await import('./src/lib/database'); await db.initializeDefaultUsers(); const u = await db.authenticateUser('maria_acosta-purp.com.mx', 'Purp_*2023@'); console.log('user?', u?.email); })();"`
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed08a4f8832089758b9cdea06f09