### PR TITLE
Use dynamic import for Toaster

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import InstallButton from "../components/InstallButton";
-import { Toaster } from "sonner";
+import dynamic from "next/dynamic";
 import type React from "react";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
@@ -8,6 +8,11 @@ import Providers from "@/components/providers";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 const inter = Inter({ subsets: ["latin"] });
+
+const Toaster = dynamic(
+  () => import("sonner").then((mod) => mod.Toaster),
+  { ssr: false }
+);
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
## Summary
- load `Toaster` from `sonner` via `next/dynamic` with `ssr: false`

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ef258ed08320898b2478c67c3498