### PR TITLE
Add PWA manifest and head link

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "PWA",
+  "short_name": "PWA",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="manifest" href="/manifest.json" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `public/manifest.json` with PWA metadata
- reference manifest in application head

## Testing
- `npm test` *(fails: Test Suites: 3 failed, 3 total)*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68acfd37b454832084c62ca082f11524