### PR TITLE
refactor: use shared sanitize in chart component

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,12 +1,8 @@
 "use client";
 import * as React from "react";
 import * as RechartsPrimitive from "recharts";
-// Simple sanitize function to escape HTML (replace with a proper library if needed)
-function sanitize(input: string): string {
-  const div = document.createElement("div");
-  div.textContent = input;
-  return div.innerHTML;
-}
+
+import { sanitize } from "@/lib/sanitize";
 import { cn } from "@/lib/utils";
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;


### PR DESCRIPTION
## Summary
- reuse shared `sanitize` helper in chart component
- remove in-file sanitize function

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@/app/(protected)/dashboard/page' in tests)*
- `pnpm test` *(fails: Jest configuration / module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acfd3a4e5c8320aae80cece4ca157c