### PR TITLE
Add unit tests for database utilities and auth slice

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,10 +3,10 @@ export default {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/$1",
+    "^@/(.*)$": "<rootDir>/src/$1",
   },
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.tsx?$": ["ts-jest", { tsconfig: { jsx: "react-jsx" } }],
   },
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],
 };

--- a/tests/AccessControl.test.tsx
+++ b/tests/AccessControl.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { store } from "@/lib/store";
-import Dashboard from "@/app/(protected)/dashboard/page";
+import Dashboard from "@/app/principal/page";
 import { setUser } from "@/lib/store/authSlice";
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
 describe("Control de acceso por rol", () => {
-  it("debe mostrar el dashboard solo al rol 'manager'", () => {
+  it("muestra el panel para el rol 'manager'", () => {
     store.dispatch(
       setUser({
         id: "user_1",
@@ -16,6 +20,10 @@ describe("Control de acceso por rol", () => {
         isActive: true,
       }),
     );
+    store.dispatch({
+      type: "auth/load/fulfilled",
+      payload: { user: store.getState().auth.user, token: "token" },
+    });
 
     render(
       <Provider store={store}>
@@ -23,10 +31,10 @@ describe("Control de acceso por rol", () => {
       </Provider>,
     );
 
-    expect(screen.getByText("Bienvenido")).toBeInTheDocument();
+    expect(screen.getByText(/Panel de Control/)).toBeInTheDocument();
   });
 
-  it("no debe mostrar el dashboard si el rol no es 'manager'", () => {
+  it("oculta el panel si el rol no es 'manager'", () => {
     store.dispatch(
       setUser({
         id: "user_2",
@@ -37,6 +45,10 @@ describe("Control de acceso por rol", () => {
         isActive: true,
       }),
     );
+    store.dispatch({
+      type: "auth/load/fulfilled",
+      payload: { user: store.getState().auth.user, token: "token" },
+    });
 
     render(
       <Provider store={store}>
@@ -44,6 +56,6 @@ describe("Control de acceso por rol", () => {
       </Provider>,
     );
 
-    expect(screen.queryByText("Bienvenido")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Panel de Control/)).not.toBeInTheDocument();
   });
 });

--- a/tests/authSlice.test.ts
+++ b/tests/authSlice.test.ts
@@ -1,0 +1,91 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer, {
+  loginUser,
+  logoutUser,
+  loadUserFromStorage,
+} from '@/lib/store/authSlice';
+import * as db from '@/lib/database';
+
+jest.mock('@/lib/database', () => ({
+  authenticateUser: jest.fn(),
+  startSync: jest.fn(),
+  stopSync: jest.fn(),
+  loginOnlineToCouchDB: jest.fn(),
+  logoutOnlineSession: jest.fn(),
+  guardarUsuarioOffline: jest.fn(),
+  findUserByEmail: jest.fn(),
+}));
+
+describe('authSlice', () => {
+  const sampleUser = {
+    _id: 'user_test',
+    id: 'user_test',
+    name: 'Test',
+    email: 'test@example.com',
+    password: '123',
+    role: 'user',
+    permissions: ['read'],
+    isActive: true,
+    createdAt: 'now',
+    updatedAt: 'now',
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('login offline falls back to local authentication', async () => {
+    (db.loginOnlineToCouchDB as jest.Mock).mockRejectedValue(new Error('offline'));
+    (db.authenticateUser as jest.Mock).mockResolvedValue(sampleUser);
+
+    const store = configureStore({ reducer: { auth: authReducer } });
+    await store.dispatch(loginUser({ email: sampleUser.email, password: sampleUser.password }) as any);
+    const state = store.getState().auth;
+
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.user?.email).toBe(sampleUser.email);
+    expect(state.token).toBe('offline');
+    expect(window.localStorage.getItem('auth')).toBeTruthy();
+  });
+
+  it('logout clears session and calls database logout', async () => {
+    (db.stopSync as jest.Mock).mockResolvedValue(undefined);
+    (db.logoutOnlineSession as jest.Mock).mockResolvedValue(undefined);
+
+    window.localStorage.setItem('auth', JSON.stringify({ user: sampleUser, token: 'token123' }));
+    const store = configureStore({
+      reducer: { auth: authReducer },
+      preloadedState: {
+        auth: {
+          user: sampleUser,
+          token: 'token123',
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+        },
+      },
+    });
+
+    await store.dispatch(logoutUser() as any);
+    const state = store.getState().auth;
+
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.user).toBeNull();
+    expect(window.localStorage.getItem('auth')).toBeNull();
+    expect(db.stopSync).toHaveBeenCalled();
+    expect(db.logoutOnlineSession).toHaveBeenCalled();
+  });
+
+  it('loadUserFromStorage hydrates state', async () => {
+    window.localStorage.setItem('auth', JSON.stringify({ user: sampleUser, token: 'abc123' }));
+    const store = configureStore({ reducer: { auth: authReducer } });
+    await store.dispatch(loadUserFromStorage());
+    const state = store.getState().auth;
+
+    expect(state.user).toEqual(sampleUser);
+    expect(state.token).toBe('abc123');
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.isLoading).toBe(false);
+  });
+});

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -1,0 +1,79 @@
+// Mock PouchDB and pouchdb-find before importing the module under test
+jest.mock('pouchdb', () => {
+  const PouchDBMock = jest.fn();
+  (PouchDBMock as any).plugin = jest.fn();
+  return { __esModule: true, default: PouchDBMock };
+});
+jest.mock('pouchdb-find', () => ({ __esModule: true, default: jest.fn() }));
+
+describe('database', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_COUCHDB_URL = 'http://localhost:5984/gestion_pwa';
+    // stub global fetch to avoid network calls
+    (global as any).fetch = jest.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+  });
+
+  it('startSync starts replication only once', async () => {
+    const PouchDBMock = require('pouchdb').default as jest.Mock;
+    const syncHandler = { on: jest.fn().mockReturnThis(), cancel: jest.fn() };
+    const localDB = { sync: jest.fn(() => syncHandler) };
+    const remoteDB = {};
+    PouchDBMock.mockImplementationOnce(() => localDB).mockImplementationOnce(() => remoteDB);
+
+    const db = await import('@/lib/database');
+    const first = await db.startSync();
+    expect(localDB.sync).toHaveBeenCalledTimes(1);
+    expect(first).toBe(syncHandler);
+
+    const second = await db.startSync();
+    expect(localDB.sync).toHaveBeenCalledTimes(1);
+    expect(second).toBe(syncHandler);
+  });
+
+  it('updateUser updates existing user document', async () => {
+    const PouchDBMock = require('pouchdb').default as jest.Mock;
+    const existing = {
+      _id: 'user:alice',
+      _rev: '1',
+      type: 'user',
+      id: 'user_alice',
+      name: 'Alice',
+      email: 'alice@example.com',
+      password: 'pass',
+      role: 'user',
+      permissions: ['read'],
+      isActive: true,
+      createdAt: '2020-01-01T00:00:00.000Z',
+      updatedAt: '2020-01-01T00:00:00.000Z',
+    } as any;
+    const store: Record<string, any> = { [existing._id]: existing };
+    const localDB = {
+      get: jest.fn(async (id: string) => store[id]),
+      put: jest.fn(async (doc: any) => {
+        store[doc._id] = doc;
+        return { ok: true };
+      }),
+      sync: jest.fn(),
+    };
+    const remoteDB = {};
+    PouchDBMock.mockImplementationOnce(() => localDB).mockImplementationOnce(() => remoteDB);
+
+    const db = await import('@/lib/database');
+    const result = await db.updateUser(existing._id, { name: 'Alice B' });
+    expect(result.name).toBe('Alice B');
+    expect(localDB.put).toHaveBeenCalled();
+    expect(store[existing._id].name).toBe('Alice B');
+  });
+
+  it('updateUser throws if identifier is missing', async () => {
+    const PouchDBMock = require('pouchdb').default as jest.Mock;
+    const localDB = { get: jest.fn(), put: jest.fn(), sync: jest.fn() };
+    const remoteDB = {};
+    PouchDBMock.mockImplementationOnce(() => localDB).mockImplementationOnce(() => remoteDB);
+
+    const db = await import('@/lib/database');
+    await expect(db.updateUser({} as any)).rejects.toThrow('updateUser: falta identificador');
+  });
+});

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -1,16 +1,34 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import LoginForm from "@/components/LoginForm";
+import { Provider } from "react-redux";
+import { LoginForm } from "@/components/auth/login-form";
+import { store } from "@/lib/store";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+beforeEach(() => {
+  store.dispatch({ type: "auth/load/fulfilled", payload: { user: null, token: null } });
+});
 
 describe("LoginForm", () => {
   it("should render email and password inputs", () => {
-    render(<LoginForm />);
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    render(
+      <Provider store={store}>
+        <LoginForm />
+      </Provider>,
+    );
+    expect(screen.getByLabelText(/correo/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/contraseña/i)).toBeInTheDocument();
   });
 
   it("should show error on empty submit", async () => {
-    render(<LoginForm />);
-    fireEvent.click(screen.getByRole("button"));
-    expect(await screen.findByText(/required/i)).toBeInTheDocument();
+    render(
+      <Provider store={store}>
+        <LoginForm />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /iniciar sesión/i }));
+    expect(await screen.findByText(/correo es requerido/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add Jest config for JSX transform and path aliases
- test database sync start and user updates
- cover authSlice offline login, logout and persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acfd3bbdd083208517c23fe87d453f