### PR TITLE
Fix login request payload to use email

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -35,9 +35,9 @@ function AuthBootstrap({ children }: { children: React.ReactNode }) {
     (async () => {
       if (user && typeof navigator !== "undefined" && navigator.onLine) {
         try {
-          const id = user.email || user.name;
-          if (id && user.password) {
-            await loginOnlineToCouchDB(id, user.password);
+          const email = user.email || user.name;
+          if (email && user.password) {
+            await loginOnlineToCouchDB(email, user.password);
             await startSync();
           }
         } catch {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -138,9 +138,9 @@ export async function stopSync() {
 }
 
 /** Login online contra /api/auth/login */
-export async function loginOnlineToCouchDB(name: string, password: string) {
-  console.log("[db] loginOnlineToCouchDB start", { name });
-  const body = JSON.stringify({ name, password });
+export async function loginOnlineToCouchDB(email: string, password: string) {
+  console.log("[db] loginOnlineToCouchDB start", { email });
+  const body = JSON.stringify({ email, password });
   let res: Response;
   try {
     res = await fetchWithTimeout(


### PR DESCRIPTION
## Summary
- Send `email` field to `/api/auth/login` instead of `name`
- Refresh session in provider using email identifier

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae375df5548320a33f4b886ac8b064