### PR TITLE
Handle logout when Couch proxy is unavailable

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,11 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 
+function buildExpiredCookie(proto: string, host: string) {
+  const parts = [
+    "AuthSession=",
+    "Max-Age=0",
+    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    "Path=/",
+    "SameSite=Lax",
+    "HttpOnly",
+  ];
+  const isSecure = proto === "https" && Boolean(host);
+  if (isSecure) parts.push("Secure");
+  return parts.join("; ");
+}
+
 async function handle(req: NextRequest) {
+  const proto = req.headers.get("x-forwarded-proto") || "http";
+  const host = req.headers.get("host") || "";
+  const origin = `${proto}://${host}`;
+  const cookie = req.headers.get("cookie") || "";
+  const expireCookie = buildExpiredCookie(proto, host);
+
   try {
-    const proto = req.headers.get("x-forwarded-proto") || "http";
-    const host = req.headers.get("host") || "";
-    const origin = `${proto}://${host}`;
-    const cookie = req.headers.get("cookie") || "";
     const couchRes = await fetch(`${origin}/api/couch/_session`, {
       method: "DELETE",
       headers: cookie ? { cookie } : undefined,
@@ -24,14 +40,18 @@ async function handle(req: NextRequest) {
     }
 
     const data = await couchRes.json().catch(() => ({}));
-    const status = couchRes.ok ? 200 : couchRes.status || 500;
-    const res = NextResponse.json({ ok: couchRes.ok, data }, { status });
-    if (setCookie) res.headers.set("set-cookie", setCookie);
+    const ok = couchRes.ok || couchRes.status === 401 || couchRes.status === 403;
+    const status = ok ? 200 : couchRes.status || 500;
+    const res = NextResponse.json({ ok, data }, { status });
     res.headers.set("Cache-Control", "no-store");
+    res.headers.set("set-cookie", setCookie || expireCookie);
     return res;
   } catch (error) {
     console.error("[auth/logout] unexpected", (error as any)?.message || error);
-    return NextResponse.json({ ok: false, error: "logout failed" }, { status: 500 });
+    const res = NextResponse.json({ ok: false, error: "logout failed" }, { status: 200 });
+    res.headers.set("Cache-Control", "no-store");
+    res.headers.set("set-cookie", expireCookie);
+    return res;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the logout API clears the AuthSession cookie even if the Couch proxy is unreachable
- treat 401/403 responses from Couch as successful logouts and fall back to an expired cookie when needed

## Testing
- attempted `npm run lint` (aborted because the command prompts for interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68db5431e8d483208b326187092136f0